### PR TITLE
CI: Make crates.io publish a manual workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,11 @@
 name: Publish Queueme To crates.io
 
 on:
-  push:
-    branches:
-      - main
+#  push:
+#    branches:
+#      - main
+  workflow_dispatch:
+
 
 jobs:
   publish:


### PR DESCRIPTION
Until the project becomes a bit more mature I'm going to make this a purely manual workflow.